### PR TITLE
Fix inverted condition so RAPL works

### DIFF
--- a/powerstat.c
+++ b/powerstat.c
@@ -1740,7 +1740,7 @@ static int rapl_get_domains(void)
 		rapl_info_t *rapl;
 
 		/* Ignore duplicated RAPL info from mmio */
-		if (strncmp(entry->d_name, "intel-rapl-mmio", 15))
+		if (!strncmp(entry->d_name, "intel-rapl-mmio", 15))
 			continue;
 		/* Ignore non Intel RAPL interfaces */
 		if (strncmp(entry->d_name, "intel-rapl", 10))


### PR DESCRIPTION
The existing code ignores all files in powercap class, meaning that `powerstat -R` doesn't actually work.