### PR TITLE
Fix build with glibc-2.38

### DIFF
--- a/powerstat.c
+++ b/powerstat.c
@@ -331,6 +331,7 @@ static const int signals[] = {
 #endif
 };
 
+#if !(__GLIBC_PREREQ(2, 38))
 /*
  *  strlcpy()
  *	BSD strlcpy
@@ -359,6 +360,7 @@ static size_t strlcpy(char *dst, const char *src, size_t len)
 	}
 	return (s - src - 1);
 }
+#endif /* !(__GLIBC_PREREQ(2, 38)) */
 
 /*
  *   set_prioity


### PR DESCRIPTION
* based on https://github.com/alsa-project/alsa-utils/commit/d6a71bfbde9e1710743d3a446c6ea3b41c45234e

* strlcat and strlcpy have been added to glibc 2.38. update the defines to use the glibc versions, and not conflict with string.h.

  ref: https://sourceware.org/git/?p=glibc.git;a=commit;h=454a20c8756c9c1d55419153255fc7692b3d2199

* fixes:
```
powerstat.c:338:15: error: static declaration of 'strlcpy' follows non-static declaration
  338 | static size_t strlcpy(char *dst, const char *src, size_t len)
      |               ^~~~~~~
In file included from powerstat.c:29:
/OE/build/luneos-nanbield/tmp-glibc/work/corei7-64-webos-linux/powerstat/0.02.27+gitAUTOINC+556762740c-r0/recipe-sysroot/usr/include/string.h:506:15: note: previous declaration of 'strlcpy' with type 'size_t(char * restrict,  const char * restrict,  size_t)' {aka 'long unsigned int(char * restrict,  const char * restrict,  long unsigned int)'}
  506 | extern size_t strlcpy (char *__restrict __dest,
      |               ^~~~~~~
make: *** [<builtin>: powerstat.o] Error 1
```